### PR TITLE
Bump dependencies for for ELPA installations

### DIFF
--- a/helm-chrome.el
+++ b/helm-chrome.el
@@ -5,7 +5,7 @@
 ;; Author: KAWABATA, Taichi <kawabata.taichi_at_gmail.com>
 ;; Created: 2013-12-25
 ;; Version: 1.131226
-;; Package-Requires: ((helm "1.0"))
+;; Package-Requires: ((helm "1.0") (cl-lib "0.3") (emacs "24"))
 ;; Keywords: tools
 ;; Human-Keywords: chrome bookmarks
 ;; URL: https://github.com/kawabata/helm-chrome


### PR DESCRIPTION
When installing this package from [MELPA](http://melpa.milkbox.net/) (or any other ELPA repository in which it might be found) then `cl-lib` should also be installed. This commit adds the corresponding Package-Requires header to install it. Feel free to adjust the required version if desired. And Add dependency on Emacs 24 for using `lexical-binding`.
