### PR TITLE
Check argument is associate list

### DIFF
--- a/helm-chrome.el
+++ b/helm-chrome.el
@@ -58,16 +58,17 @@
 
 (defun helm-chrome--add-bookmark (json)
   "Add bookmarks from JSON."
-  (cond
-   ((assoc 'roots json)
-    (dolist (item (cdr (assoc 'roots json)))
-      (helm-chrome--add-bookmark item)))
-   ((equal (cdr (assoc 'type json)) "folder")
-    (cl-loop for item across (cdr (assoc 'children json))
-             do (helm-chrome--add-bookmark item)))
-   ((equal (cdr (assoc 'type json)) "url")
-    (puthash (cdr (assoc 'name json)) (cdr (assoc 'url json))
-             helm-chrome--bookmarks))))
+  (when (and (listp json) (listp (cdr json)))
+    (cond
+     ((assoc 'roots json)
+      (dolist (item (cdr (assoc 'roots json)))
+        (helm-chrome--add-bookmark item)))
+     ((equal (cdr (assoc 'type json)) "folder")
+      (cl-loop for item across (cdr (assoc 'children json))
+               do (helm-chrome--add-bookmark item)))
+     ((equal (cdr (assoc 'type json)) "url")
+      (puthash (cdr (assoc 'name json)) (cdr (assoc 'url json))
+               helm-chrome--bookmarks)))))
 
 (defun helm-chrome-reload-bookmarks ()
   "Reload Chrome bookmarks."


### PR DESCRIPTION
I got following error when argument of 'helm-chrome--add-bookmark' is
`(meta_info . "{\"sync\":{\"transaction_version\":\"113\"}}")`.

```
cond: Wrong type argument: listp, "{\"sync\":{\"transaction_version\":\"113\"}}"
Beginning of buffer
```

Please see this patch.
